### PR TITLE
Module config update doesn't work as expected

### DIFF
--- a/include/flexisip/module.hh
+++ b/include/flexisip/module.hh
@@ -110,6 +110,8 @@ protected:
 	ModuleInfoBase *mInfo = nullptr;
 	GenericStruct *mModuleConfig = nullptr;
 	std::unique_ptr<EntryFilter> mFilter;
+	bool mDirtyConfig = false;
+
 };
 
 // -----------------------------------------------------------------------------

--- a/src/module.cc
+++ b/src/module.cc
@@ -44,23 +44,22 @@ bool Module::isEnabled() const {
 }
 
 bool Module::doOnConfigStateChanged(const ConfigValue &conf, ConfigState state) {
-	bool dirtyConfig = false;
 	LOGD("Configuration of module %s changed for key %s to %s", mInfo->getModuleName().c_str(), conf.getName().c_str(),
 		 conf.get().c_str());
 	switch (state) {
 		case ConfigState::Check:
 			return isValidNextConfig(conf);
 		case ConfigState::Changed:
-			dirtyConfig = true;
+			mDirtyConfig = true;
 			break;
 		case ConfigState::Reset:
-			dirtyConfig = false;
+			mDirtyConfig = false;
 			break;
 		case ConfigState::Commited:
-			if (dirtyConfig) {
+			if (mDirtyConfig) {
 				LOGI("Reloading config of module %s", mInfo->getModuleName().c_str());
 				reload();
-				dirtyConfig = false;
+				mDirtyConfig = false;
 			}
 			break;
 	}


### PR DESCRIPTION
How to reproduce:
Build Flexisip with SNMP support

snmpset -m FLEXISIP-MIB  -v 2c -c private localhost FLEXISIP-MIB::flexisipMIB.flexisip.module<someModule>.<someSetting>.0 s <someValue>

Verify that log "Congiguration of module <name> changed for key...." but module is not reloaded

Root cause:
----------
bool dirtyConfig=false is local variable.
When doConfigStateChanged is called twice with Changed->Committed - old value of local variable 'dirtyConfig' is destroyed

Fix:
----
Make dirtyConfig flag as a Module class member.
This is the easiest but not perfect solution as it affects all 'derived' classes (need to recompile all modules)
Anyway I don't see acceptable fix for this without affecting public header "module.hh"

Better suggestions:
-----
To avoid adding members to public classes, I'd recommend to use 'private implementation' approach for storing all 'Module' internals