### PR TITLE
RFC1918 address support

### DIFF
--- a/src/module-nat-helper.cc
+++ b/src/module-nat-helper.cc
@@ -218,7 +218,25 @@ private:
 		fixTransport(ms->getHome(), path, transport);
 	}
 	bool isPrivateAddress(const char *host) {
-		return strstr(host, "10.") == host || strstr(host, "192.168.") == host || strstr(host, "176.12.") == host;
+ 			return strstr(host,"10.") == host //RFC1918 Class A
+ 				|| strstr(host,"192.168.") == host //RFC1918 Class C
+				|| strstr(host,"176.12.") == host //Not RFC1918 Flexisip ???
+				|| strstr(host,"172.16.") == host //RFC1918 Class B (from this line until the end of the condition)
+				|| strstr(host,"172.17.") == host
+				|| strstr(host,"172.18.") == host
+				|| strstr(host,"172.19.") == host
+				|| strstr(host,"172.20.") == host
+				|| strstr(host,"172.21.") == host
+				|| strstr(host,"172.22.") == host
+				|| strstr(host,"172.23.") == host
+				|| strstr(host,"172.24.") == host
+				|| strstr(host,"172.25.") == host
+				|| strstr(host,"172.26.") == host
+				|| strstr(host,"172.27.") == host
+				|| strstr(host,"172.28.") == host
+				|| strstr(host,"172.29.") == host
+				|| strstr(host,"172.30.") == host
+				|| strstr(host,"172.31.") == host;
 	}
 	void fixRecordRouteInRequest(shared_ptr<MsgSip> &ms) {
 		sip_t *sip = ms->getSip();

--- a/src/pushnotification/apple/apple-client.cc
+++ b/src/pushnotification/apple/apple-client.cc
@@ -27,7 +27,7 @@ using namespace std;
 namespace flexisip {
 namespace pushnotification {
 
-std::string AppleClient::APN_DEV_ADDRESS{"api.development.push.apple.com"};
+std::string AppleClient::APN_DEV_ADDRESS{"api.sandbox.push.apple.com"};
 std::string AppleClient::APN_PROD_ADDRESS{"api.push.apple.com"};
 std::string AppleClient::APN_PORT{"443"};
 
@@ -40,9 +40,10 @@ AppleClient::AppleClient(sofiasip::SuRoot& root,
 	ostringstream os{};
 	os << "AppleClient[" << this << "]";
 	mLogPrefix = os.str();
-	SLOGD << mLogPrefix << ": constructing AppleClient";
+	SLOGD << mLogPrefix << ": constructing AppleClient certName: " << certName;
 
-	const auto apn_server = (certName.find(".dev") != string::npos) ? APN_DEV_ADDRESS : APN_PROD_ADDRESS;
+	const auto apn_server = StringUtils::endsWith(certName, ".dev") ? APN_DEV_ADDRESS : APN_PROD_ADDRESS;
+	SLOGD << mLogPrefix << ": APNS server " << apn_server;
 	mHttp2Client = Http2Client::make(root, apn_server, APN_PORT, trustStorePath, certPath);
 }
 


### PR DESCRIPTION
Hi,

The isPrivateAddress function support only the class A and C IP address. This modification can allow support all class defined in RFC1918 and 176.12 address for compatibility with old version