### PR TITLE
fix(event-logs): bound CallQualityStatisticsLog report by payload length

### DIFF
--- a/src/eventlogs/events/eventlogs.cc
+++ b/src/eventlogs/events/eventlogs.cc
@@ -210,7 +210,11 @@ void AuthLog::write(EventLogWriter& writer) const {
 }
 
 CallQualityStatisticsLog::CallQualityStatisticsLog(const sip_t* sip)
-    : EventLog(sip), mReport{sip->sip_payload && sip->sip_payload->pl_data ? sip->sip_payload->pl_data : nullptr} {}
+    // Build the report bounded by pl_len. The const char* constructor would read until the next NUL byte, which
+    // overruns into the following SIP message when several are coalesced in the same TCP buffer (no NUL after a body).
+    : EventLog(sip), mReport{(sip->sip_payload && sip->sip_payload->pl_data)
+                                 ? std::string(sip->sip_payload->pl_data, sip->sip_payload->pl_len)
+                                 : std::string()} {}
 
 void CallQualityStatisticsLog::write(EventLogWriter& writer) const {
 	writer.write(*this);


### PR DESCRIPTION
## Problem

`CallQualityStatisticsLog` stores the body of an incoming `application/vq-rtcpxr`
PUBLISH into `mReport`. The constructor built the string from the payload pointer
using the `std::string(const char*)` constructor:

```cpp
mReport{sip->sip_payload && sip->sip_payload->pl_data ? sip->sip_payload->pl_data : nullptr}
```

That constructor reads until the next NUL byte and ignores pl_len. sofia-sip
does not guarantee a NUL terminator right after a message body, and over a stream
transport (TCP) several SIP messages are frequently coalesced in the same receive
buffer. As a result the stored report overruns past the end of the payload into
the following SIP message — typically the next PUBLISH, whose raw request line
and headers (including the Proxy-Authorization digest) then end up appended to
the recorded report.

Symptoms

- Entries written by the event-logs module (e.g. under statistics_reports/)
contain a valid vq-rtcpxr report followed by a raw PUBLISH sip:… SIP/2.0 block
and its headers.
- Incidental leak of a request's Proxy-Authorization digest into the logs.

The exact overrun content is non-deterministic: it depends on what happens to sit
after the body in the buffer, so it only shows up under TCP with back-to-back
messages.

Fix

Construct mReport bounded by the payload length, capturing exactly the body:

```cpp
mReport{(sip->sip_payload && sip->sip_payload->pl_data)
            ? std::string(sip->sip_payload->pl_data, sip->sip_payload->pl_len)
            : std::string()}
```

Impact

- Recorded quality reports now contain only the report body.
- No API/behaviour change beyond the corrected bounds; no configuration change.