### PR TITLE
fix(event-logs): insert quality reports into the existing table

### DIFF
--- a/src/eventlogs/writers/database-event-log-writer.cc
+++ b/src/eventlogs/writers/database-event-log-writer.cc
@@ -322,7 +322,7 @@ DataBaseEventLogWriter::DataBaseEventLogWriter(const std::string& backendString,
 		    "INSERT INTO event_auth_log VALUES (" + lastIdFunction + ", :method, :origin, :userExists)";
 
 		mInsertReq[SqlCallQualityEventLogId] =
-		    "INSERT INTO event_call_quality_log VALUES (" + lastIdFunction + ", :report)";
+		    "INSERT INTO event_call_quality_statistics_log VALUES (" + lastIdFunction + ", :report)";
 
 		mIsReady = true;
 	} catch (exception const& e) {


### PR DESCRIPTION
## Problem

When `event-logs/logger` is set to `database`, call quality statistics reports
(`VQSessionReport`) are never stored.

The table created by the writer and the one targeted by the `INSERT` have different names:

database-event-log-writer.cc:246  CREATE TABLE IF NOT EXISTS event_call_quality_statistics_log
database-event-log-writer.cc:325  INSERT INTO event_call_quality_log

`event_call_quality_log` is never created anywhere in the repository, so the insertion always
fails. Other event log types (registrations, calls, messages, auth) are unaffected.

## Fix

Align the `INSERT` with the name of the table that is actually created.